### PR TITLE
add new option - sum

### DIFF
--- a/lib/redmine_wiki_lists/ref_issues.rb
+++ b/lib/redmine_wiki_lists/ref_issues.rb
@@ -20,6 +20,7 @@ usage: {{ref_issues([option].., [column]..)}}<br>
 -t[=column] : display text<br>
 -l[=column] : display linked text<br>
 -c : count issues<br>
+-sum[=column] : sum column<br>
 -0 : no display if no issues
 <br>[columns]<br> {
 TEXT
@@ -197,6 +198,23 @@ TEXT
           end
         elsif parser.count_flag
           disp = @issues.size.to_s
+        elsif parser.sum_field
+          sum = 0.0
+          atr = parser.sum_field if parser.sum_field
+
+          @issues.each do |issue|
+            if issue.attributes.has_key?(atr)
+              sum = sum + issue.attributes[atr].to_f
+            else
+              issue.custom_field_values.each do |cf|
+                if 'cf_'+cf.custom_field.id.to_s == atr || cf.custom_field.name == atr
+                  sum = sum + cf.value.to_f
+                end
+              end
+            end
+          end
+
+          disp = sum.to_s
         else
           if params[:format] == 'pdf'
             disp = render(partial: 'issues/list.html', locals: {issues: @issues, query: @query})

--- a/lib/redmine_wiki_lists/ref_issues/parser.rb
+++ b/lib/redmine_wiki_lists/ref_issues/parser.rb
@@ -5,7 +5,7 @@ module RedmineWikiLists
   module RefIssues
     class Parser
       attr_reader :search_words_s, :search_words_d, :search_words_w, :columns,
-                  :custom_query_name, :custom_query_id, :additional_filter, :only_text, :only_link, :count_flag, :zero_flag
+                  :custom_query_name, :custom_query_id, :additional_filter, :only_text, :only_link, :count_flag, :zero_flag, :sum_field
 
       def initialize(obj, args = nil, project = nil)
         parse_args(obj, args, project) if args
@@ -24,6 +24,7 @@ module RedmineWikiLists
         @only_text = nil
         @count_flag = nil
         @zero_flag = nil
+        @sum_field = nil
 
         args.each do |arg|
           arg.strip!
@@ -99,6 +100,12 @@ module RedmineWikiLists
               @count_flag = true
             when '0'
               @zero_flag = true
+            when 'sum'
+              if sep
+                @sum_field = words
+              else
+                raise "- no sum field:#{arg}"
+              end
             else
               raise "- unknown option:#{arg}"
           end


### PR DESCRIPTION
sum機能の追加です。
-sum=コラム名と入力した場合に、数値フィールドの合計値が出せます。
-cオプション指定されている場合は動作せず、対象コラムがfloatやinteger型以外では0.0が返ります。