### PR TITLE
Add display limit feature to ref_issues macro to prevent server overload

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,3 @@
+en:
+  ref_issues:
+    display_limit_reached: "* Display limit (%{limit} issues) reached. Total: %{total} issues. Use -n=NUMBER to change the limit."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,2 @@
 en:
-  ref_issues:
-    display_limit_reached: "* Display limit (%{limit} issues) reached. Total: %{total} issues. Use -n=NUMBER to change the limit."
+  ref_issues_display_limit_reached: "* Display limit (%{limit} issues) reached. Total: %{total} issues. Use -n=NUMBER to change the limit."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,3 @@
+ja:
+  ref_issues:
+    display_limit_reached: "※ 表示件数が上限(%{limit}件)に達しました。全 %{total} 件。-n=件数 で上限を変更できます。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,3 +1,2 @@
 ja:
-  ref_issues:
-    display_limit_reached: "※ 表示件数が上限(%{limit}件)に達しました。全 %{total} 件。-n=件数 で上限を変更できます。"
+  ref_issues_display_limit_reached: "※ 表示件数が上限(%{limit}件)に達しました。全 %{total} 件。-n=件数 で上限を変更できます。"

--- a/lib/redmine_wiki_lists/ref_issues.rb
+++ b/lib/redmine_wiki_lists/ref_issues.rb
@@ -163,7 +163,7 @@ TEXT
           disp = String.new
         elsif parser.only_text || parser.only_link
           if total_count > parser.display_limit && !parser.display_limit_specified
-            disp = "<p>#{I18n.t('ref_issues.display_limit_reached', limit: parser.display_limit, total: total_count)}</p>"
+            disp = "<p>#{I18n.t('ref_issues_display_limit_reached', limit: parser.display_limit, total: total_count)}</p>"
           else
             disp = String.new
           end
@@ -205,7 +205,7 @@ TEXT
           disp = total_count.to_s
         else
           if total_count > parser.display_limit && !parser.display_limit_specified
-            disp = "<p>#{I18n.t('ref_issues.display_limit_reached', limit: parser.display_limit, total: total_count)}</p>"
+            disp = "<p>#{I18n.t('ref_issues_display_limit_reached', limit: parser.display_limit, total: total_count)}</p>"
           else
             disp = String.new
           end

--- a/lib/redmine_wiki_lists/ref_issues/parser.rb
+++ b/lib/redmine_wiki_lists/ref_issues/parser.rb
@@ -149,12 +149,12 @@ module RedmineWikiLists
         if @custom_query_id
           @query = IssueQuery.visible.find_by_id(@custom_query_id)
           raise "- can not find CustomQuery ID:'#{@custom_query_id}'" unless @query
-        elsif @custom_query_name then
+        elsif @custom_query_name
           cond = 'project_id IS NULL'
           cond += " OR project_id = #{project.id}" if project
-          cond = "(#{cond}) AND name = '#{@custom_query_name}'"
-          @query = IssueQuery.where(cond).where(user_id: User.current.id).first
-          @query = IssueQuery.where(cond).where(visibility: Query::VISIBILITY_PUBLIC).first unless @query
+          base_query = IssueQuery.where(cond).where(name: @custom_query_name)
+          @query = base_query.where(user_id: User.current.id).first
+          @query = base_query.where(visibility: Query::VISIBILITY_PUBLIC).first unless @query
           raise "- can not find CustomQuery Name:'#{@custom_query_name}'" unless @query
         else
           @query = IssueQuery.new(name: '_', filters: {})

--- a/lib/redmine_wiki_lists/ref_issues/parser.rb
+++ b/lib/redmine_wiki_lists/ref_issues/parser.rb
@@ -139,6 +139,8 @@ module RedmineWikiLists
         return true if @search_words_d.present?
         return true if @search_words_w.present?
         return true if @additional_filter.present?
+        return true if @restrict_project
+        return true if @display_limit_specified
         false
       end
 


### PR DESCRIPTION
以下のような修正を行いましたので、もしよろしければ、取り込みをお願いします。

## 概要

ref_issues マクロに表示件数の制限機能を追加しました。
意図せず大量のチケットを表示してしまった場合のサーバー負荷を防止します。

## 変更内容

- デフォルトで表示件数を 100 件に制限
- `-n` オプションで表示件数を指定可能（最大 1000 件）
- デフォルト上限を超えた場合、警告メッセージを表示
- 日本語・英語の多言語対応

## 使用例

{{ref_issues(-f:status=open)}}           # 最大 100 件（デフォルト）
{{ref_issues(-f:status=open, -n=500)}}   # 最大 500 件